### PR TITLE
Update infoblox_ipam_agent.py

### DIFF
--- a/networking_infoblox/neutron/cmd/eventlet/infoblox_ipam_agent.py
+++ b/networking_infoblox/neutron/cmd/eventlet/infoblox_ipam_agent.py
@@ -36,6 +36,7 @@ def register_options():
 
 
 def main():
+    common_config.register_common_config_options()
     common_config.init(sys.argv[1:])
     common_config.setup_logging()
     register_options()


### PR DESCRIPTION
Changes to support Zed release

Zed releases require the following approach [1] for importing config options. Without this change the plugin fails to load and simply errors out.

[1] https://review.opendev.org/c/openstack/neutron/+/837392